### PR TITLE
Tensorboard video

### DIFF
--- a/dreamer/algos/dreamer_algo.py
+++ b/dreamer/algos/dreamer_algo.py
@@ -258,7 +258,7 @@ class Dreamer(RlAlgorithm):
         """
         lead_dim, batch_t, batch_b, img_shape = infer_leading_dims(observation, 3)
         model = self.agent.model
-        ground_truth = observation[:, :n].type(self.type) / 255.0
+        ground_truth = observation[:, :n] + 0.5
         reconstruction = image_pred.mean[:t, :n]
 
         prev_state = post[t - 1, :n]

--- a/dreamer/algos/dreamer_algo.py
+++ b/dreamer/algos/dreamer_algo.py
@@ -243,8 +243,8 @@ class Dreamer(RlAlgorithm):
             loss_info = LossInfo(model_loss, actor_loss, value_loss, prior_ent, post_ent, div, reward_loss, image_loss)
 
             if self.log_video:
-                # if opt_itr == self.train_steps - 1 and sample_itr % self.video_every == 0:
-                self.write_videos(observation, action, image_pred, post, step=sample_itr)
+                if opt_itr == self.train_steps - 1 and sample_itr % self.video_every == 0:
+                    self.write_videos(observation, action, image_pred, post, step=sample_itr)
 
         return loss, loss_info
 

--- a/dreamer/utils/logging.py
+++ b/dreamer/utils/logging.py
@@ -1,0 +1,7 @@
+from rlpyt.utils.logging import logger
+from torch.utils.tensorboard.writer import SummaryWriter
+
+
+def video_summary(tag, video, step=None, fps=20):
+    writer: SummaryWriter = logger.get_tf_summary_writer()
+    writer.add_video(tag=tag, vid_tensor=video, global_step=step, fps=fps)

--- a/main.py
+++ b/main.py
@@ -17,6 +17,7 @@ def build_and_train(log_dir, game="pong", run_ID=0, cuda_idx=None, eval=False):
         game=game,
         frame_shape=(64, 64),  # dreamer uses this, default is 80, 104
         frame_skip=2,  # because dreamer action repeat = 2
+        num_img_obs=1,  # get only the last observation. returns black and white frame
         repeat_action_probability=0.25  # Atari-v0 repeat action probability = 0.25
     )
     factory_method = make_wapper(AtariEnv, [OneHotAction], [{}])

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,5 @@ psutil
 pyprind
 rlpyt
 tqdm
+tensorboard
+moviepy


### PR DESCRIPTION
I wrote a method to save videos to tensorboard. ~~But when looking at the ground truth frames, all of them are black. Not sure what went wrong here yet.~~ Additionally, it did not look like the model was learning to output black frames, but might be because I haven't trained long enough. If you do decide to train for a while, I suggest uncommenting `dreamer_algo.py` line 246: `if opt_itr == self.train_steps - 1 and sample_itr % self.video_every == 0:`. This way, videos aren't generated every optimization step.

TODO:

- [x] Figure out why sampled trajectories are all black.
- [ ] Make sure the observation decoder model is learning.
- [ ] Atari observations are grayscale images. We might need to change that to RGB images at some point.
- [x] Test on DMC and see what the output is.
