### PR TITLE
Split loss

### DIFF
--- a/dreamer/algos/dreamer_algo.py
+++ b/dreamer/algos/dreamer_algo.py
@@ -11,7 +11,7 @@ from dreamer.algos.replay import initialize_replay_buffer, samples_to_buffer
 from dreamer.models.rnns import get_feat, get_dist
 from dreamer.utils.logging import video_summary
 
-torch.autograd.set_detect_anomaly(True)  # used for debugging gradients
+# torch.autograd.set_detect_anomaly(True)  # used for debugging gradients
 
 loss_info_fields = ['model_loss', 'actor_loss', 'value_loss', 'prior_entropy', 'post_entropy', 'divergence',
                     'reward_loss', 'image_loss']

--- a/dreamer/algos/dreamer_algo.py
+++ b/dreamer/algos/dreamer_algo.py
@@ -11,6 +11,8 @@ from dreamer.algos.replay import initialize_replay_buffer, samples_to_buffer
 from dreamer.models.rnns import get_feat, get_dist
 from dreamer.utils.logging import video_summary
 
+torch.autograd.set_detect_anomaly(True)  # used for debugging gradients
+
 loss_info_fields = ['model_loss', 'actor_loss', 'value_loss', 'prior_entropy', 'post_entropy', 'divergence',
                     'reward_loss', 'image_loss']
 LossInfo = namedarraytuple('LossInfo', loss_info_fields)

--- a/dreamer/algos/dreamer_algo.py
+++ b/dreamer/algos/dreamer_algo.py
@@ -54,7 +54,9 @@ class Dreamer(RlAlgorithm):
             type=torch.float,
             prefill=5000,
             log_video=True,
-            video_every=int(1e1)
+            video_every=int(1e1),
+            video_summary_t=25,
+            video_summary_b=4,
     ):
         super().__init__()
         if optim_kwargs is None:
@@ -265,7 +267,8 @@ class Dreamer(RlAlgorithm):
 
             if self.log_video:
                 if opt_itr == self.train_steps - 1 and sample_itr % self.video_every == 0:
-                    self.write_videos(observation, action, image_pred, post, step=sample_itr)
+                    self.write_videos(observation, action, image_pred, post, step=sample_itr, n=self.video_summary_b,
+                                      t=self.video_summary_t)
 
         return model_loss, actor_loss, value_loss, loss_info
 

--- a/dreamer/models/rnns.py
+++ b/dreamer/models/rnns.py
@@ -192,8 +192,9 @@ class RSSMRollout(RollOutModule):
         priors = []
         actions = []
         for t in range(steps):
-            state = self.transition_model(action, state)
-            action, _ = policy(buffer_method(state, 'detach'))  # stop gradients here to only optimize policy
+            with torch.no_grad():  # stop gradients here to only optimize policy
+                state = self.transition_model(action, state)
+            action, _ = policy(state)
             priors.append(state)
             actions.append(action)
         priors = stack_states(priors, dim=0)

--- a/tests/dreamer/test_main.py
+++ b/tests/dreamer/test_main.py
@@ -1,3 +1,5 @@
+import datetime
+import os
 import platform
 
 from rlpyt.runners.minibatch_rl import MinibatchRlEval, MinibatchRl
@@ -61,7 +63,11 @@ def build_and_train(log_dir, game="pong", run_ID=0, cuda_idx=None, eval=False):
 
 
 def test_main():
+    log_dir = os.path.join(
+        os.path.dirname(__file__),
+        'data',
+        'test',
+        datetime.datetime.now().strftime("%Y%m%d"))
     if platform.system() == 'Darwin':  # if mac-os
         return
-    logdir = 'data/tests/'
-    build_and_train(logdir)
+    build_and_train(log_dir)

--- a/tests/dreamer/test_main.py
+++ b/tests/dreamer/test_main.py
@@ -1,0 +1,63 @@
+from rlpyt.runners.minibatch_rl import MinibatchRlEval, MinibatchRl
+from rlpyt.samplers.serial.sampler import SerialSampler
+from rlpyt.utils.logging.context import logger_context
+
+from dreamer.agents.atari_dreamer_agent import AtariDreamerAgent
+from dreamer.algos.dreamer_algo import Dreamer
+from dreamer.envs.modified_atari import AtariEnv, AtariTrajInfo
+from dreamer.envs.one_hot import OneHotAction
+from dreamer.envs.wrapper import make_wapper
+
+
+def build_and_train(log_dir, game="pong", run_ID=0, cuda_idx=None, eval=False):
+    env_kwargs = dict(
+        game=game,
+        frame_shape=(64, 64),  # dreamer uses this, default is 80, 104
+        frame_skip=2,  # because dreamer action repeat = 2
+        num_img_obs=1,  # get only the last observation. returns black and white frame
+        repeat_action_probability=0.25  # Atari-v0 repeat action probability = 0.25
+    )
+    factory_method = make_wapper(AtariEnv, [OneHotAction], [{}])
+    sampler = SerialSampler(
+        EnvCls=factory_method,
+        TrajInfoCls=AtariTrajInfo,  # default traj info + GameScore
+        env_kwargs=env_kwargs,
+        eval_env_kwargs=env_kwargs,
+        batch_T=1,
+        batch_B=1,
+        max_decorrelation_steps=0,
+        eval_n_envs=10,
+        eval_max_steps=int(10e3),
+        eval_max_trajectories=5,
+    )
+    algo = Dreamer(
+        batch_size=1,
+        batch_length=5,
+        train_every=10,
+        train_steps=1,
+        prefill=10,
+        horizon=5,
+        replay_size=100,
+        log_video=False,
+        kl_scale=0.1)
+    agent = AtariDreamerAgent(
+        train_noise=0.4, eval_noise=0, expl_type="epsilon_greedy", expl_min=0.1, expl_decay=2000/0.3)
+    runner_cls = MinibatchRlEval if eval else MinibatchRl
+    runner = runner_cls(
+        algo=algo,
+        agent=agent,
+        sampler=sampler,
+        n_steps=20,
+        log_interval_steps=10,
+        affinity=dict(cuda_idx=cuda_idx),
+    )
+    config = dict(game=game)
+    name = "dreamer_" + game
+    with logger_context(log_dir, run_ID, name, config, snapshot_mode="last", override_prefix=True,
+                        use_summary_writer=True):
+        runner.train()
+
+
+def test_main():
+    logdir = 'data/tests/'
+    build_and_train(logdir)

--- a/tests/dreamer/test_main.py
+++ b/tests/dreamer/test_main.py
@@ -1,3 +1,5 @@
+import platform
+
 from rlpyt.runners.minibatch_rl import MinibatchRlEval, MinibatchRl
 from rlpyt.samplers.serial.sampler import SerialSampler
 from rlpyt.utils.logging.context import logger_context
@@ -59,5 +61,7 @@ def build_and_train(log_dir, game="pong", run_ID=0, cuda_idx=None, eval=False):
 
 
 def test_main():
+    if platform.system() == 'Darwin':  # if mac-os
+        return
     logdir = 'data/tests/'
     build_and_train(logdir)

--- a/tests/dreamer/test_main.py
+++ b/tests/dreamer/test_main.py
@@ -13,7 +13,7 @@ from dreamer.envs.one_hot import OneHotAction
 from dreamer.envs.wrapper import make_wapper
 
 
-def build_and_train(log_dir, game="pong", run_ID=0, cuda_idx=None, eval=False):
+def build_and_train(game="pong", run_ID=0, cuda_idx=None, eval=False):
     env_kwargs = dict(
         game=game,
         frame_shape=(64, 64),  # dreamer uses this, default is 80, 104
@@ -55,19 +55,10 @@ def build_and_train(log_dir, game="pong", run_ID=0, cuda_idx=None, eval=False):
         log_interval_steps=10,
         affinity=dict(cuda_idx=cuda_idx),
     )
-    config = dict(game=game)
-    name = "dreamer_" + game
-    with logger_context(log_dir, run_ID, name, config, snapshot_mode="last", override_prefix=True,
-                        use_summary_writer=True):
-        runner.train()
+    runner.train()
 
 
 def test_main():
-    log_dir = os.path.join(
-        os.path.dirname(__file__),
-        'data',
-        'test',
-        datetime.datetime.now().strftime("%Y%m%d"))
     if platform.system() == 'Darwin':  # if mac-os
         return
-    build_and_train(log_dir)
+    build_and_train()


### PR DESCRIPTION
- Returns model_loss, value_loss, and actor_loss separately so their gradients can be computed separately.
- Multiplies the image_loss by the image size (like in the tf codebase)
- Adjusts logging hyperparameters to log more frequently and show more observed frames.

Note: 
After running this overnight, we see that model_loss (image_loss + reward_loss) is not diverging any more.  The return_loss and agent_loss still are (probably due to the same cause, since both of them are based on the returns tensor).  So I don't think our algorithm is correct yet, but hopefully less broken.


(Currently set to merge into tensorboard-video since I branched off that.  If you're planning on merging tensorboard-video into master first, we could merge this into master instead.)