### PR TITLE
change to floatbox so it doesn't crash with dmc

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -13,6 +13,7 @@ jobs:
       matrix:
         os: [ubuntu-16.04, ubuntu-18.04, windows-2019, macos-10.15]
         python-version: [3.6, 3.7]
+          pytorch-version: [1.4.0, 1.5.0]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
@@ -24,7 +25,7 @@ jobs:
         python -m pip install --upgrade pip setuptools wheel
     - name: Install PyTorch
       run: |
-        pip install torch==1.4.0+cpu torchvision==0.5.0+cpu -f https://download.pytorch.org/whl/torch_stable.html || pip install torch==1.4.0 torchvision==0.5.0
+        pip install torch==${{ matrix.pytorch-version }}+cpu torchvision==0.6.0+cpu -f https://download.pytorch.org/whl/torch_stable.html || pip install torch==${{ matrix.pytorch-version }} torchvision==0.6.0
     - name: Install dependencies
       run: |
         pip install git+https://github.com/astooke/rlpyt.git

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         os: [ubuntu-16.04, ubuntu-18.04, windows-2019, macos-10.15]
         python-version: [3.6, 3.7]
-          pytorch-version: [1.4.0, 1.5.0]
+        pytorch-version: [1.4.0, 1.5.0]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/dreamer/envs/normalize_actions.py
+++ b/dreamer/envs/normalize_actions.py
@@ -1,7 +1,7 @@
 import numpy as np
 import gym
 from dreamer.envs.wrapper import EnvWrapper
-
+from rlpyt.spaces.float_box import FloatBox
 
 class NormalizeActions(EnvWrapper):
 
@@ -17,7 +17,7 @@ class NormalizeActions(EnvWrapper):
     def action_space(self):
         low = np.where(self._mask, -np.ones_like(self._low), self._low)
         high = np.where(self._mask, np.ones_like(self._low), self._high)
-        return gym.spaces.Box(low, high, dtype=np.float32)
+        return FloatBox(low, high, dtype=np.float32)
 
     def step(self, action):
         original = (action + 1) / 2 * (self._high - self._low) + self._low

--- a/dreamer/models/agent.py
+++ b/dreamer/models/agent.py
@@ -64,7 +64,7 @@ class AgentModel(nn.Module):
         action_dist = self.action_decoder(feat)
         if self.action_dist == 'tanh_normal':
             if self.training:  # use agent.train(bool) or agent.eval()
-                action = action_dist.sample()
+                action = action_dist.rsample()
             else:
                 action = action_dist.mode()
         elif self.action_dist == 'one_hot':

--- a/dreamer/models/rnns.py
+++ b/dreamer/models/rnns.py
@@ -197,7 +197,7 @@ class RSSMRollout(RollOutModule):
 
         state = buffer_method(state, 'detach')
         for t in range(steps):
-            action, _ = policy(state)
+            action, _ = policy(buffer_method(state, 'detach'))
             state = self.transition_model(action, state)
             next_states.append(state)
             actions.append(action)

--- a/dreamer/models/rnns.py
+++ b/dreamer/models/rnns.py
@@ -195,8 +195,9 @@ class RSSMRollout(RollOutModule):
         for p in self.transition_model.parameters():
             p.requires_grad = False
 
+        state = buffer_method(state, 'detach')
         for t in range(steps):
-            action, _ = policy(buffer_method(state, 'detach'))
+            action, _ = policy(state)
             state = self.transition_model(action, state)
             next_states.append(state)
             actions.append(action)

--- a/dreamer/models/rnns.py
+++ b/dreamer/models/rnns.py
@@ -178,25 +178,31 @@ class RSSMRollout(RollOutModule):
             priors.append(state)
         return stack_states(priors, dim=0)
 
-    def rollout_policy(self, steps: int, policy, prev_action: torch.Tensor, prev_state: RSSMState):
+    def rollout_policy(self, steps: int, policy, prev_state: RSSMState):
         """
         Roll out the model with a policy function.
         :param steps: number of steps to roll out
         :param policy: RSSMState -> action
-        :param prev_action: size(batch_size, action_size)
         :param prev_state: RSSM state, size(batch_size, state_size)
-        :return: prior states size(time_steps, batch_size, state_size),
+        :return: next states size(time_steps, batch_size, state_size),
                  actions size(time_steps, batch_size, action_size)
         """
-        state, action = prev_state, prev_action
-        priors = []
+        state = prev_state
+        next_states = []
         actions = []
+
+        # freeze state transition model parameters as only action model gradients needed
+        for p in self.transition_model.parameters():
+            p.requires_grad = False
+
         for t in range(steps):
-            with torch.no_grad():  # stop gradients here to only optimize policy
-                state = self.transition_model(action, state)
-            action, _ = policy(state)
-            priors.append(state)
+            action, _ = policy(buffer_method(state, 'detach'))
+            state = self.transition_model(action, state)
+            next_states.append(state)
             actions.append(action)
-        priors = stack_states(priors, dim=0)
+        next_states = stack_states(next_states, dim=0)
         actions = torch.stack(actions, dim=0)
-        return priors, actions
+
+        for p in self.transition_model.parameters():
+            p.requires_grad = True
+        return next_states, actions

--- a/tests/dreamer/models/test_rnns.py
+++ b/tests/dreamer/models/test_rnns.py
@@ -57,7 +57,7 @@ def test_rollouts():
     assert post.deter.shape == (time_steps, batch_size, deterministic_size)
 
     prior = rollout_module.rollout_transition(time_steps, action, transition_model.initial_state(batch_size))
-    assert isinstance(post, RSSMState)
+    assert isinstance(prior, RSSMState)
     assert prior.mean.shape == (time_steps, batch_size, stochastic_size)
     assert prior.std.shape == (time_steps, batch_size, stochastic_size)
     assert prior.stoch.shape == (time_steps, batch_size, stochastic_size)
@@ -70,9 +70,7 @@ def test_rollouts():
         action_dist = SampleDist(torch.distributions.Normal(mean, std))
         return action, action_dist
 
-    prev_action = torch.randn(batch_size, action_size)
-    prior, actions = rollout_module.rollout_policy(time_steps, policy, prev_action,
-                                                   transition_model.initial_state(batch_size))
+    prior, actions = rollout_module.rollout_policy(time_steps, policy, post[-1])
     assert isinstance(prior, RSSMState)
     assert prior.mean.shape == (time_steps, batch_size, stochastic_size)
     assert prior.std.shape == (time_steps, batch_size, stochastic_size)


### PR DESCRIPTION
Currently, the normalize actions wrapper uses a Box ActionSpace, which raises and error when rlpyt tries to call it's missing null_value function.  This changes it to use a FloatBox, which does have a null value.

Edit: This PR also changes the loss order around so pytorch doesn't yell at us and re-calls parameters() each time we do grad clipping.  It runs on the newest version of pytorch now.