### PR TITLE
fix discounting

### DIFF
--- a/dreamer/algos/dreamer_algo.py
+++ b/dreamer/algos/dreamer_algo.py
@@ -258,8 +258,7 @@ class Dreamer(RlAlgorithm):
         discount_arr = self.discount * torch.ones_like(imag_reward)
         returns = self.compute_return(imag_reward[:-1], value[:-1], discount_arr[:-1],
                                       bootstrap=value[-1], lambda_=self.discount_lambda)
-        discount = torch.cumprod(discount_arr[:-1], 1)
-
+        discount = torch.cumprod(discount_arr[:-1], 0)
         actor_loss = -torch.mean(discount * returns)
 
         # ------------------------------------------  Gradient Barrier  ------------------------------------------------

--- a/dreamer/algos/dreamer_algo.py
+++ b/dreamer/algos/dreamer_algo.py
@@ -258,6 +258,8 @@ class Dreamer(RlAlgorithm):
         discount_arr = self.discount * torch.ones_like(imag_reward)
         returns = self.compute_return(imag_reward[:-1], value[:-1], discount_arr[:-1],
                                       bootstrap=value[-1], lambda_=self.discount_lambda)
+        # Make the top row 1 so the cumulative product starts with discount^0
+        discount_arr[0] = 1
         discount = torch.cumprod(discount_arr[:-1], 0)
         actor_loss = -torch.mean(discount * returns)
 


### PR DESCRIPTION
Fixes a bug where we were discounting over the batch dimension rather than the horizon dimension.

Also make the discount factor we multiply each element with start with discount^0 at the first timestep rather than discount^1.