### PR TITLE
change batch size to match paper

### DIFF
--- a/dreamer/algos/dreamer_algo.py
+++ b/dreamer/algos/dreamer_algo.py
@@ -25,7 +25,7 @@ class Dreamer(RlAlgorithm):
 
     def __init__(
             self,  # Hyper-parameters
-            batch_size=16,
+            batch_size=50,
             batch_length=50,
             train_every=1000,
             train_steps=100,


### PR DESCRIPTION
They use batch size 50 in the Dreamer paper.
IDK how sensitive performance is to batch size, but we're testing it here: https://tensorboard.dev/experiment/apJY3tnIQlCXWDUKVTkPyw/#scalars
Alternatively, we could consider adjusting 50 up or down to a power of 2 (32 or 64).