### PR TITLE
Fix the loss computation bug.

### DIFF
--- a/dreamer/algos/dreamer_algo.py
+++ b/dreamer/algos/dreamer_algo.py
@@ -213,7 +213,7 @@ class Dreamer(RlAlgorithm):
 
         prev_state = model.representation.initial_state(batch_b, device=action.device, dtype=action.dtype)
         # Rollout model by taking the same series of actions as the real model
-        post, prior = model.rollout.rollout_representation(batch_t, embed, action, prev_state)
+        prior, post = model.rollout.rollout_representation(batch_t, embed, action, prev_state)
         # Flatten our data (so first dimension is batch_t * batch_b = batch_size)
         # since we're going to do a new rollout starting from each state visited in each batch.
 


### PR DESCRIPTION
It seems the order of prior and post is wrong because in "rnns.py" the "rollout_representation" function returns "prior" and "post", but here we got "post" and "prior".