### PR TITLE
fix bug of wrong image dist leading to wrong prob

### DIFF
--- a/dreamer/algos/dreamer_algo.py
+++ b/dreamer/algos/dreamer_algo.py
@@ -224,9 +224,7 @@ class Dreamer(RlAlgorithm):
         image_pred = model.observation_decoder(feat)
         reward_pred = model.reward_model(feat)
         reward_loss = -torch.mean(reward_pred.log_prob(reward))
-        img_count = np.prod(observation.shape[-3:])
         image_loss = -torch.mean(image_pred.log_prob(observation))
-        image_loss = image_loss * img_count
         pcont_loss = torch.tensor(0.)  # placeholder if use_pcont = False
         if self.use_pcont:
             pcont_pred = model.pcont(feat)

--- a/dreamer/models/observation.py
+++ b/dreamer/models/observation.py
@@ -39,12 +39,10 @@ class ObservationEncoder(nn.Module):
 
 
 class ObservationDecoder(nn.Module):
-    def __init__(self, depth=32, stride=2, activation=nn.ReLU, embed_size=1024, shape=(3, 64, 64),
-                 distribution=td.Normal):
+    def __init__(self, depth=32, stride=2, activation=nn.ReLU, embed_size=1024, shape=(3, 64, 64)):
         super().__init__()
         self.depth = depth
         self.shape = shape
-        self.distribution = distribution
 
         c, h, w = shape
         conv1_kernel_size = 6
@@ -85,7 +83,7 @@ class ObservationDecoder(nn.Module):
         x = torch.reshape(x, (squeezed_size, *self.conv_shape))
         x = self.decoder(x)
         mean = torch.reshape(x, (*batch_shape, *self.shape))
-        obs_dist = self.distribution(mean, 1)
+        obs_dist = td.Independent(td.Normal(mean, 1), len(self.shape))
         return obs_dist
 
 

--- a/dreamer/models/rnns.py
+++ b/dreamer/models/rnns.py
@@ -24,7 +24,7 @@ def get_feat(rssm_state: RSSMState):
 
 
 def get_dist(rssm_state: RSSMState):
-    return td.Normal(rssm_state.mean, rssm_state.std)
+    return td.independent.Independent(td.Normal(rssm_state.mean, rssm_state.std), 1)
 
 
 class TransitionBase(nn.Module):


### PR DESCRIPTION
The original implementation of image dist didn't use correct batch_dim and event_dim. It instead tried a fix by scaling image_loss by image count manually. This, however, won't give correct probability as in official tf2 implementation, by a factor of pixels in image. As a fix, using td.Independent will give the correct distribution

```
import torch
import torch.distributions as td
import tensorflow as tf
from tensorflow_probability import distributions as tfd

def test1():
    batch_size = 5
    mean_image = torch.zeros((batch_size, 3, 64, 64))
    obs_dist = td.Independent(td.Normal(mean_image, 1), 3)
    torch_prob = torch.mean(obs_dist.log_prob(mean_image))

    mean_image = tf.zeros((batch_size, 3, 64, 64))
    obs_dist = tfd.Independent(tfd.Normal(mean_image, 1), 3)
    tf_prob = tf.reduce_mean(obs_dist.log_prob(mean_image))

    print(torch_prob.item())
    tf.print(tf_prob)

test1()
```